### PR TITLE
商品詳細表示サーバーサイド一部実装

### DIFF
--- a/app/assets/stylesheets/modules/items.scss
+++ b/app/assets/stylesheets/modules/items.scss
@@ -479,6 +479,18 @@ ul li{
             }
           }
         }
+        .item-buy-btn {
+          font-size: 24px;
+          background-color: red;
+          line-height: 60px;
+          margin-top: 16px;
+          text-align: center;
+          a {
+            color: #fff;
+            text-decoration: none;
+            font-weight: 600;
+          }
+        }
       }
     }
   }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.where("name LIKE ?", "%#{params[:name]}%")
+    @item = Item.all
   end
 
   def new
@@ -13,14 +13,17 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @items = Item.all
-    @image = Image.find(params[:id])
-    @images = Image.all
+    # @image = Image.find(params[:id])
+    # @images = Image.all
   end
 
-  def new
+  def edit
   end
 
-  def create
+  def update
   end
   
+  def destroy
+
+  end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,8 +13,6 @@ class ItemsController < ApplicationController
   def show
     @item = Item.find(params[:id])
     @items = Item.all
-    # @image = Image.find(params[:id])
-    # @images = Image.all
   end
 
   def edit

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -89,28 +89,31 @@
           お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
   %section.pickup_product
     .pickup_product__header
-      ピックアップカテゴリー
+      ピックアップカテゴリー 
     .pickup_product__title
       新規商品一覧
     .pickup_product__box
       %ul.item_lists
         %li.item_list
           .item_list__image
-            = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
+            = link_to '/items/1' do
+              = image_tag ("https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png")
           .item_list__name
             aaaaa
           .item_list__price
             50000円
         %li.item_list
           .item_list__image
-            = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png"
+            = link_to '/items/2' do
+              = image_tag ("https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png")
           .item_list__name
             eeeee
           .item_list__price
             4000円
         %li.item_list
           .item_list__image
-            = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png"
+            = link_to '/items/3' do
+              = image_tag ("https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/7/a001.png")
           .item_list__name
             rrrrrr
           .item_list__price

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,4 @@
+= render partial: 'items/header'
 .main
   .main__showmain
     .main__showmain__content
@@ -57,3 +58,13 @@
               %tr
                 %th 発送日の目安
                 %td 4-7で発送
+        - if user_signed_in? && current_user.id == @item.seller_id
+          .item-buy-btn
+            = link_to "商品の編集", edit_item_path
+          .item-buy-btn
+            = link_to "この商品を削除する", item_path, method: :delete
+        - else
+          .item-buy-btn
+            = link_to "購入画面に進む"
+= render partial: 'items/app_banner'
+= render partial: 'items/footer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root 'items#index'
 
-  resources :items, only: [:new,:create, :show]
+  resources :items, exept: [:index]
   resources :profiles,only: [:new,:create]
 end


### PR DESCRIPTION
＃What
商品詳細表示サーバーサイドの一部実装。controllerにedit,update,destroyアクション追加。詳細ページ（未ログイン状態）に購入ボタン追加。「出品者にしか商品の情報編集・削除のリンクが踏めないようになっている」機能は別トピックブランチで実装予定。

＃Why
商品の重要な機能である「ログアウト状態でも商品詳細ページを見ることができる」機能と「出品者以外にしか商品購入機能のリンクが踏めないようになっている」機能を追加するため。