### PR TITLE
パンくずリスト実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,6 +100,7 @@ gem 'dotenv-rails'
 
 gem 'ancestry'
 
+gem "gretel"
 
 group :tools do
   gem 'squasher', '>= 0.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -422,6 +424,7 @@ DEPENDENCIES
   dotenv-rails
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/modules/mypage.scss
+++ b/app/assets/stylesheets/modules/mypage.scss
@@ -318,3 +318,21 @@
     }
   }
 }
+
+  .breadcrumbs{
+    display: flex;
+    justify-content: center;
+    .breadcrumb-inner{
+      height: 40px;
+      line-height: 40px;
+      width: 950px;
+      padding: 0 15px 0;
+      color: $emerald-blue;
+      font-weight: bold;
+      a{
+        text-decoration: none;
+        color:  darkslategrey;
+      }
+  }
+}
+  

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,4 +1,6 @@
 = render  partial:"items/header"
+- breadcrumb :CardNew
+= render "layouts/breadcrumbs"
 
 .mypage-main-contents
   .mypage-main-content-inner

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,4 +1,7 @@
 = render  partial:"items/header"
+- breadcrumb :CardShow
+= render "layouts/breadcrumbs"
+
 
 .mypage-main-contents
   .mypage-main-content-inner

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,5 +1,5 @@
 = render  partial:"items/header"
-- breadcrumb :CardShow
+- breadcrumb :cardshow
 = render "layouts/breadcrumbs"
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,6 @@
 = render partial: 'items/header'
+- breadcrumb :items
+= render "layouts/breadcrumbs"
 
 .main
   .main__showmain

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,4 +1,5 @@
 = render partial: 'items/header'
+
 .main
   .main__showmain
     .main__showmain__content

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,0 +1,2 @@
+.breadcrumbs
+  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/layouts/_breadcrumbs.html.haml
+++ b/app/views/layouts/_breadcrumbs.html.haml
@@ -1,2 +1,3 @@
 .breadcrumbs
-  = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"
+  .breadcrumb-inner
+    = breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list"

--- a/app/views/profiles/logout.html.haml
+++ b/app/views/profiles/logout.html.haml
@@ -1,4 +1,7 @@
 = render partial:"items/header"
+- breadcrumb :logout
+= render "layouts/breadcrumbs"
+
 
 
 .mypage-main-contents

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,4 +1,6 @@
 = render partial:"items/header"
+- breadcrumb :profile
+= render "layouts/breadcrumbs"
 
 
 

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,4 +1,5 @@
 = render partial:"items/header"
+
 - breadcrumb :profile
 = render "layouts/breadcrumbs"
 

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,51 @@
+crumb :root do
+  link "FURIMA", root_path
+end
+
+crumb :profile do
+  link "マイページ", profile_path(current_user)
+  parent :root
+end
+
+crumb :logout do
+  link "ログアウト", logout_profiles_path
+  parent :profile
+end
+
+crumb :CardShow do
+  link "登録カード情報", card_path
+  parent :profile
+end
+
+
+crumb :CardNew do
+  link "カード登録", card_path(current_user)
+  parent :profile
+end
+
+
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -12,40 +12,17 @@ crumb :logout do
   parent :profile
 end
 
-crumb :CardShow do
+crumb :cardshow do
   link "登録カード情報", card_path
   parent :profile
 end
-
 
 crumb :CardNew do
   link "カード登録", card_path(current_user)
   parent :profile
 end
 
-
-
-# crumb :projects do
-#   link "Projects", projects_path
-# end
-
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
-
-# crumb :project_issues do |project|
-#   link "Issues", project_issues_path(project)
-#   parent :project, project
-# end
-
-# crumb :issue do |issue|
-#   link issue.title, issue_path(issue)
-#   parent :project_issues, issue.project
-# end
-
-# If you want to split your breadcrumbs configuration over multiple files, you
-# can create a folder named `config/breadcrumbs` and put your configuration
-# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
-# folder are loaded and reloaded automatically when you change them, just like
-# this file (`config/breadcrumbs.rb`).
+crumb :items do
+  link "商品情報", item_path,@item
+  parent :root
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_161259) do
+ActiveRecord::Schema.define(version: 2020_03_30_161258) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture", null: false
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2020_03_30_161259) do
     t.text "content", null: false
     t.integer "price", null: false
     t.integer "seller_id"
+    t.integer "buyer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "postage_payer_id", null: false
@@ -68,7 +69,6 @@ ActiveRecord::Schema.define(version: 2020_03_30_161259) do
     t.string "brand"
     t.bigint "item_situation_id"
     t.bigint "user_id"
-    t.integer "buyer_id"
     t.bigint "category_id"
     t.index ["category_id"], name: "index_items_on_category_id"
     t.index ["item_condition_id"], name: "index_items_on_item_condition_id"


### PR DESCRIPTION
#  what
パンくずリストの実装
　ヘッダーの利用のあるページに対してパンくずリストを実装。
　（商品詳細ページ/マイページ/クレジットカード登録ページ/クレジットカード情報確認ページ/ログアウトページ）
　今後追加実装予定ページについては適宜実装する

#  why
ユーザビリティ向上のため